### PR TITLE
Fix testRenameWithValidNameFromDropDownMenu / Dropdown menu step

### DIFF
--- a/src/test/java/school/redrover/FolderTest.java
+++ b/src/test/java/school/redrover/FolderTest.java
@@ -36,7 +36,7 @@ public class FolderTest extends BaseTest {
         getDriver().findElement(By.linkText("Dashboard")).click();
 
         getDriver().findElement(By.xpath("//*[@id='job_" + folderName + "']/td[3]/a")).click();
-        getDriver().findElement(By.linkText("Rename")).click();
+        getDriver().findElement(By.xpath("//a[@href='/job/Folder1/confirm-rename']")).click();
         getDriver().findElement(By.name("newName")).clear();
         getDriver().findElement(By.name("newName")).sendKeys(renamedFolder);
         getDriver().findElement(By.name("Submit")).click();


### PR DESCRIPTION
Fix testRenameWithValidNameFromDropDownMenu / Dropdown menu step

Before:
- 39 `getDriver().findElement(By.linkText("Rename")).click();`

After:
- 39 `getDriver().findElement(By.xpath("//a[@href='/job/Folder1/confirm-rename']")).click();`