### PR TITLE
AddNewTestClickLogoToMainPage

### DIFF
--- a/src/test/java/school/redrover/HeaderTest.java
+++ b/src/test/java/school/redrover/HeaderTest.java
@@ -15,4 +15,14 @@ public class HeaderTest extends BaseTest {
 
         Assert.assertTrue(getDriver().getTitle().contains("Dashboard"));
     }
+    @Test
+    public void testClickLogoToMainPage() {
+
+        getDriver().findElement(By.xpath("//a[@href='/me/my-views']")).click();
+
+        getDriver().findElement(By.id("jenkins-head-icon")).click();
+
+        Assert.assertTrue(
+                getDriver().findElement(By.cssSelector(".empty-state-block > h1")).getText().contains("Welcome to Jenkins!"));
+    }
 }


### PR DESCRIPTION
https://trello.com/c/qwNTgAEY/45-us14001-header-return-to-the-dashboard-page-with-one-click

To verify that a user, who is logged in and using Jenkins, can easily navigate to the Dashboard (Main) page by clicking the Jenkins logo in the left top corner from any page on the Jenkins site.