### PR TITLE
TC_10.002.07 | Views > Edit view > Verify no jobs are shown on the Dashboard when the View with no associated jobs is selected

### DIFF
--- a/src/test/java/school/redrover/View3Test.java
+++ b/src/test/java/school/redrover/View3Test.java
@@ -129,4 +129,21 @@ public class View3Test extends BaseTest {
                 getDriver().findElement(By.xpath("//div[@id = 'description']/div[1]")).getText(),
                 "");
     }
+    @Test
+    public void testNoJobsShownForTheViewWithoutAssociatedJob() {
+        final String newFreeStyleProjectName = "FreeStyleTestProject";
+        final String newListViewName = "ListViewTest";
+        final String noAssociatedJobsForTheViewMessage = "This view has no jobs associated with it. " +
+                "You can either add some existing jobs to this view or create a new job in this view.";
+
+        createFreeStyleProject(newFreeStyleProjectName);
+        createListViewWithoutAssociatedJob(newListViewName);
+        returnToJenkinsHomepage();
+
+        getDriver().findElement(By.xpath("//a[@href = '/view/" + newListViewName + "/']")).click();
+
+        Assert.assertTrue(
+                getDriver().findElement(By.xpath("//div[@id = 'main-panel']")).getText().
+                        contains(noAssociatedJobsForTheViewMessage));
+    }
 }


### PR DESCRIPTION
https://trello.com/c/O5vV1WRW/308-tc1000207-views-edit-view-verify-no-jobs-are-shown-on-the-dashboard-when-the-view-with-no-associated-jobs-is-selected